### PR TITLE
fix: update vscode extension name

### DIFF
--- a/scripts/programs/vscode.sh
+++ b/scripts/programs/vscode.sh
@@ -32,7 +32,7 @@ installextension jpoissonnier.vscode-styled-components
 # graphql formatter
 installextension prisma.vscode-graphql
 # go support
-installextension ms-vscode.go
+installextension golang.go
 # import cost
 installextension wix.vscode-import-cost
 # npm intellisense


### PR DESCRIPTION
It looks like [the extension](https://github.com/golang/vscode-go)'s name changed to `golang.go`.

